### PR TITLE
Add missing override reference

### DIFF
--- a/src/Slopes.js
+++ b/src/Slopes.js
@@ -57,6 +57,7 @@ export default class Slopes
 		this.overridden.processEdges = World.prototype.processEdges;
 		this.overridden.collides = SAT.collides;
 		this.overridden.fromVertices = Axes.fromVertices;
+		this.overridden.solvePosition = Resolver.solvePosition;
 		this.overridden.preSolvePosition = Resolver.preSolvePosition;
 		
 		// Override these methods


### PR DESCRIPTION
When restarting a scene, `Resolver.solvePosition` would remain undefined and crash Phaser.
```
Engine.js:197 Uncaught TypeError: Resolver.solvePosition is not a function
    at Object.Engine.update (Engine.js:197)
    at World.update (World.js:649)
    at EventEmitter.emit (index.js:203)
    at Systems.step (Systems.js:364)
    at SceneManager.update (SceneManager.js:558)
    at Game.step (Game.js:541)
    at TimeStep.step (TimeStep.js:558)
    at step (RequestAnimationFrame.js:105)
```